### PR TITLE
Update coffee-script-source

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     coffee-script (2.2.0)
       coffee-script-source
       execjs
-    coffee-script-source (1.1.3)
+    coffee-script-source (1.8.0)
     cucumber (1.1.3)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.2)


### PR DESCRIPTION
This makes installation of gems possible. But gems are outdated generally.
